### PR TITLE
Stop using the whitelist and allow c++ to catch all exceptions, everywhere

### DIFF
--- a/LegitScript/CMakeLists.txt
+++ b/LegitScript/CMakeLists.txt
@@ -37,3 +37,14 @@ target_include_directories(LegitScript PRIVATE "${CPP_PEGLIB_INCLUDE_DIR}")
 target_include_directories(LegitScript PRIVATE "${ANGELSCRIPT_DIR}/include")
 target_include_directories(LegitScript PRIVATE "${ANGELSCRIPT_DIR}/add_on")
 target_include_directories(LegitScript PRIVATE "${JSON_INCLUDE_DIR}")
+
+if (EMSCRIPTEN)
+  target_link_options(LegitScript PRIVATE
+    -fexceptions
+  )
+
+  target_compile_options(LegitScript PRIVATE
+    -O2
+    -fexceptions
+  )
+endif()

--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -9,9 +9,15 @@ target_include_directories(LegitScriptWasm PRIVATE "${LEGIT_SCRIPT_INCLUDE_DIR}"
 
 target_link_libraries(LegitScriptWasm PUBLIC embind)
 target_link_libraries(LegitScriptWasm PRIVATE LegitScript)
+
+target_compile_options(LegitScriptWasm PRIVATE
+  -fexceptions
+  -O2
+)
+
 target_link_options(LegitScriptWasm PRIVATE
   -sEXPORT_ES6=1
-  -sEXCEPTION_CATCHING_ALLOWED=LegitScriptLoad,LegitScriptFrame
+  -fexceptions
 )
 
 #install(TARGETS LegitScriptWasm DESTINATION ${CMAKE_CURRENT_LIST_DIR}/dist/)

--- a/web/demo.js
+++ b/web/demo.js
@@ -11,7 +11,12 @@ function CompileLegitScript(legitScriptCompiler, content) {
   try {
     const result = legitScriptCompiler.LegitScriptLoad(content)
     debugOutputEl.innerText = result
-    debugOutputEl.style = 'border:2px solid green'
+
+    if (result.includes('"error":')) {
+      debugOutputEl.style = 'border:2px solid yellow'
+    } else {
+      debugOutputEl.style = 'border:2px solid green'
+    }
     return true
   } catch (e) {
     debugOutputEl.innerText = `${e.name} ${e.message}\n ${e.stack}`


### PR DESCRIPTION
This also adds `-O2` which makes the resulting wasm file ~1/2 the size

before
```
221K LegitScriptWasm.js
4.8M LegitScriptWasm.wasm
```

after:
```
240K LegitScriptWasm.js
2.3M LegitScriptWasm.wasm
```

This also adds a super low effort error state for compile errors

![image](https://github.com/user-attachments/assets/a7ef92aa-dbb8-4729-912a-5a0be0e883af)
